### PR TITLE
Expand the bootstrapping to run Hippo as a service and finish enabling local dev

### DIFF
--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -7,9 +7,15 @@ echo "# make..."
 sudo apt update 
 sudo apt install -y \
          git \
-         nodejs \
-         npm \
+         pkg-config
 
+echo "# nodejs"
+curl -o https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" 
+nvm install 'v16.13.0'
+nvm use 'v16.13.0'
         
 echo "# rust..."
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -63,14 +69,58 @@ echo "# yo-wasm..."
 npm install -g yo
 npm install -g generator-wasm
 
-echo "# hipo..."
+echo "# wasmtime"
+curl https://wasmtime.dev/install.sh -sSf | bash
+export WASMTIME_HOME="$HOME/.wasmtime"
+export PATH="$WASMTIME_HOME/bin:$PATH"
+
+echo '# hippo CLI'
+wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin/ -xzf hippo-v0.9.0-linux-amd64.tar.gz
+
+echo "# hippo..."
 git clone https://github.com/deislabs/hippo.git
 cd hippo/Hippo
 dotnet restore
 npm run build
-export BINDLE_URL=http://localhost:8080/v1
-dotnet run
-wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz
-sudo tar -C /usr/local/bin/ -xzf hippo-v0.9.0-linux-amd64.tar.gz
+dotnet build
+cp -r wwwroot /home/ubuntu/hippo/Hippo/bin/Debug/net5.0/
+
+echo "# hippo daemon file..."
+sudo tee -a /etc/systemd/system/hippo.service <<'EOF'
+[Unit]
+Description=Hippo server
+[Service]
+Restart=on-failure
+RestartSec=5s
+Environment=BINDLE_URL=http://localhost:8080/v1
+Environment=ASPNETCORE_ENVIRONMENT=Development
+WorkingDirectory=/home/ubuntu/hippo/Hippo/bin/Debug/net5.0/
+ExecStart=/home/ubuntu/hippo/Hippo/bin/Debug/net5.0/hippo-server
+User=ubuntu
+Group=ubuntu
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo chmod +x /etc/systemd/system/hippo.service
+
+echo "# starting bindle ..."
+sudo systemctl enable hippo
+sudo systemctl start hippo
+
+echo "# waiting for hippo to start ..."            
+sleep 5 # wait for hippo to start
+
+sudo chown -R ubuntu:ubuntu /home/ubuntu
 
 echo "# complete!"
+echo "You can access hippo at https://localhost:5001"
+echo "You can start a new WASM project with:"
+echo "  export USER=admin"
+echo "  export HIPPO_USERNAME=admin"
+echo "  export HIPPO_PASSWORD='Passw0rd!'"
+echo "  export HIPPO_URL=https://localhost:5001"
+echo "  export BINDLE_URL=http://localhost:8080/v1"
+echo "  export GLOBAL_AGENT_FORCE_GLOBAL_AGENT=false"
+echo "  yo wasm"
+echo "and follow the prompts"

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -10,7 +10,7 @@ sudo apt install -y \
          pkg-config
 
 echo "# nodejs"
-curl -o https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" 
@@ -86,6 +86,7 @@ npm run build
 dotnet build
 cp -r wwwroot /home/ubuntu/hippo/Hippo/bin/Debug/net5.0/
 
+
 echo "# hippo daemon file..."
 sudo tee -a /etc/systemd/system/hippo.service <<'EOF'
 [Unit]
@@ -95,16 +96,18 @@ Restart=on-failure
 RestartSec=5s
 Environment=BINDLE_URL=http://localhost:8080/v1
 Environment=ASPNETCORE_ENVIRONMENT=Development
+Environment=HOME=/home/ubuntu
 WorkingDirectory=/home/ubuntu/hippo/Hippo/bin/Debug/net5.0/
 ExecStart=/home/ubuntu/hippo/Hippo/bin/Debug/net5.0/hippo-server
-User=ubuntu
-Group=ubuntu
+User=root
+Group=root
 [Install]
 WantedBy=multi-user.target
 EOF
+
 sudo chmod +x /etc/systemd/system/hippo.service
 
-echo "# starting bindle ..."
+echo "# starting hippo ..."
 sudo systemctl enable hippo
 sudo systemctl start hippo
 

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -5,5 +5,5 @@ runcmd:
 - export HOME='/home/ubuntu'
 - export USER='ubuntu'
 - cd $HOME
-- curl -L -o cloud-init.sh 'https://raw.githubusercontent.com/scotty-c/hipo-dev/main/cloud-init.sh'
+- curl -L -o cloud-init.sh 'https://raw.githubusercontent.com/scotty-c/hippo-dev/main/cloud-init.sh'
 - bash cloud-init.sh | tee output.txt


### PR DESCRIPTION
- [x] Run hippo as a service
- [x] install a current version of node to unblock errors in yeoman
- [x] install wasmtime for local dev/test
- [x] fix ownership on the `ubuntu` user's home directory